### PR TITLE
feat: add `wait-for-postgres` script

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,12 @@
       "rules": {
         "@typescript-eslint/no-unused-vars": "off"
       }
+    },
+    {
+      "files": ["**/wait-for-postgres.ts"],
+      "rules": {
+        "@typescript-eslint/no-require-imports": "off"
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Let's see what comes out.",
   "main": "index.js",
   "scripts": {
-    "dev": "npm run services:up && next dev",
+    "dev": "npm run services:up && npm run wait-for-postgres && npm run migrations:up && next dev",
     "services:up": "docker compose -f src/infra/compose.yaml up -d",
     "services:stop": "docker compose -f src/infra/compose.yaml stop",
     "services:down": "docker compose -f src/infra/compose.yaml down",
@@ -13,7 +13,8 @@
     "test": "jest --runInBand",
     "test:watch": "jest --watchAll --runInBand",
     "migrations:create": "node-pg-migrate --migrations-dir src/infra/migrations create",
-    "migrations:up": "node-pg-migrate --migrations-dir src/infra/migrations --envPath .env.development up"
+    "migrations:up": "node-pg-migrate --migrations-dir src/infra/migrations --envPath .env.development up",
+    "wait-for-postgres": "node src/infra/scripts/wait-for-postgres.ts"
   },
   "author": "",
   "license": "MIT",

--- a/src/infra/compose.yaml
+++ b/src/infra/compose.yaml
@@ -1,5 +1,6 @@
 services:
   database:
+    container_name: "postgres-dev"
     image: "postgres:17.4-alpine3.21"
     env_file:
       - ../../.env.development

--- a/src/infra/scripts/wait-for-postgres.ts
+++ b/src/infra/scripts/wait-for-postgres.ts
@@ -1,0 +1,19 @@
+const { exec } = require("node:child_process");
+
+process.stdout.write("\n🔴 Aguardando o postgres aceitar conexões.");
+
+checkPostgres();
+
+function checkPostgres() {
+  exec(
+    "docker exec postgres-dev pg_isready --host localhost",
+    (error, stdout) => {
+      if (stdout.includes("accepting connections")) {
+        console.log("\n🟢 Postgres pronto e aceitando conexões!\n");
+        return;
+      }
+      process.stdout.write(".");
+      checkPostgres();
+    },
+  );
+}


### PR DESCRIPTION
Criado script para aguardar o `postgres` estar pronto e aceitando conexões para depois rodar o script de `migrations`, ficando o seguinte `race condition`:
1) docker compose -f src/infra/compose.yaml up -d
2) node src/infra/scripts/wait-for-postgres.ts
3) node-pg-migrate --migrations-dir src/infra/migrations --envPath .env.development up
4) next dev