### PR TITLE
Padronização de controllers

### DIFF
--- a/src/app/api/v1/status/route.ts
+++ b/src/app/api/v1/status/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import database from "infra/database";
-import { InternalServerError } from "infra/errors";
+import { MethodNotAllowedError } from "infra/errors";
+import controller from "infra/controller";
 
 export async function GET() {
   try {
@@ -38,12 +39,28 @@ export async function GET() {
       { status: 200 },
     );
   } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-
-    console.error(publicErrorObject);
-
-    return NextResponse.json(publicErrorObject, { status: 500 });
+    return controller.errorHandlerResponse(error);
   }
+}
+
+export function POST() {
+  return methodNotAllowedResponse();
+}
+
+export function PUT() {
+  return methodNotAllowedResponse();
+}
+
+export function DELETE() {
+  return methodNotAllowedResponse();
+}
+
+export function PATCH() {
+  return methodNotAllowedResponse();
+}
+
+function methodNotAllowedResponse() {
+  const publicErrorObject = new MethodNotAllowedError();
+
+  return NextResponse.json(publicErrorObject, { status: 405 });
 }

--- a/src/infra/controller.ts
+++ b/src/infra/controller.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { InternalServerError } from "./errors";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function errorHandlerResponse(error: Error | any) {
+  const publicErrorObject = new InternalServerError({
+    cause: error,
+    statusCode: error.statusCode,
+  });
+
+  console.log(publicErrorObject);
+
+  return NextResponse.json(publicErrorObject, {
+    status: publicErrorObject.statusCode,
+  });
+}
+
+const controller = {
+  errorHandlerResponse,
+};
+
+export default controller;

--- a/src/infra/database.ts
+++ b/src/infra/database.ts
@@ -1,13 +1,20 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors";
 
 async function query(queryObject: object | string) {
   let client: Client | undefined;
   try {
     client = await getNewClient();
     const result = await client.query(queryObject);
+
     return result;
   } catch (error) {
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      cause: error,
+      message: "Erro na conexão com o Database ou na Query.",
+    });
+
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -2,13 +2,58 @@ export class InternalServerError extends Error {
   action: string;
   statusCode: number;
 
-  constructor({ cause }) {
+  constructor({ cause, statusCode }: { cause: Error; statusCode?: number }) {
     super("Aconteceu um erro inesperado no servidor.", {
       cause,
     });
     this.name = "InternalServerError";
     this.action = "Entre em contato com o suporte.";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  action: string;
+  statusCode: number;
+
+  constructor({ cause, message }: { cause: Error; message?: string }) {
+    super(message || "Serviço indisponível no momento.", {
+      cause,
+    });
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço está disponível.";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  action: string;
+  statusCode: number;
+
+  constructor() {
+    super("Método não permitido para este endpoint.");
+    this.name = "MethodNotAllowedError";
+    this.action =
+      "Verifique se o método HTTP enviado é válido para este endpoint.";
+    this.statusCode = 405;
   }
 
   toJSON() {

--- a/src/tests/integration/api/v1/migrations/put.test.ts
+++ b/src/tests/integration/api/v1/migrations/put.test.ts
@@ -1,0 +1,26 @@
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+describe("PUT /api/v1/migrations", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving method not allowed error handling", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/migrations", {
+        method: "PUT",
+      });
+
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        action:
+          "Verifique se o método HTTP enviado é válido para este endpoint.",
+        status_code: 405,
+      });
+    });
+  });
+});

--- a/src/tests/integration/api/v1/status/post.test.ts
+++ b/src/tests/integration/api/v1/status/post.test.ts
@@ -1,0 +1,26 @@
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving method not allowed error handling", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        action:
+          "Verifique se o método HTTP enviado é válido para este endpoint.",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Padroniza os controllers dos endpoints `/migrations` e `/status`;
- Adiciona 2 novos erros customizados: `MethodNotAllowedError` and `ServiceError`.
- Faz o `InternalServerError` aceitar injeção de `statusCode`.
